### PR TITLE
Pass `inlineCode` component into `h()`

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -583,7 +583,7 @@ function rule(node) {
  * @this {HTMLCompiler}
  */
 function inlineCode(node) {
-    return h(this, node, 'code', {}, util.collapse(this.encode(node.value)));
+    return h(this, node, 'inlineCode', {}, util.collapse(this.encode(node.value)));
 }
 
 /**

--- a/lib/h.js
+++ b/lib/h.js
@@ -56,6 +56,12 @@ function h(context, node, name, attributes, children) {
     var components = context.options.mdastReactComponents || {};
     var component = components[name] ? components[name] : name;
 
+    // If we don't have a custom component defined for inlineCode, render a
+    // standard `code` element instead
+    if (name === 'inlineCode' && !components.inlineCode) {
+      component = 'code';
+    }
+
     if (closing) {
         return context.createElement(component, attributes);
     } else {


### PR DESCRIPTION
Add support for rendering different components for both code blocks
and inline code.
